### PR TITLE
feat: delivery-server 설정 추가

### DIFF
--- a/configs/delivery-server/application.yaml
+++ b/configs/delivery-server/application.yaml
@@ -1,0 +1,40 @@
+server:
+  port: 10005
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/delivery_db
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:password}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        default_batch_fetch_size: 100
+
+  jooq:
+    sql-dialect: POSTGRES
+
+feign:
+  circuitbreaker:
+    enabled: true
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      hub-service:
+        failure-rate-threshold: 50
+        minimum-number-of-calls: 5
+        sliding-window-size: 10
+        wait-duration-in-open-state: 10s
+        permitted-number-of-calls-in-half-open-state: 3


### PR DESCRIPTION
### 📌 관련 이슈
- close #6 

### 💡 작업 내용
- delivery-server config 서버 설정 파일 추가
- 포트: 10005
- datasource, jpa, jooq, feign, resilience4j 설정 포함


### 🔍 변경 이유

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
